### PR TITLE
Take CompoundButtons drawables min size into account during measurements

### DIFF
--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
@@ -319,8 +319,7 @@ class FlexboxHelper {
      */
     void calculateVerticalFlexLines(FlexLinesResult result, int widthMeasureSpec,
             int heightMeasureSpec, int needsCalcAmount, int fromIndex,
-            @Nullable List<FlexLine> existingLines)
-    {
+            @Nullable List<FlexLine> existingLines) {
         calculateFlexLines(result, heightMeasureSpec, widthMeasureSpec, needsCalcAmount,
                 fromIndex, NO_POSITION, existingLines);
     }

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxHelper.java
@@ -19,14 +19,15 @@ package com.google.android.flexbox;
 import static com.google.android.flexbox.FlexContainer.NOT_SET;
 import static com.google.android.flexbox.FlexItem.FLEX_BASIS_PERCENT_DEFAULT;
 import static com.google.android.flexbox.FlexItem.FLEX_GROW_DEFAULT;
-import static com.google.android.flexbox.FlexItem.FLEX_SHRINK_DEFAULT;
 import static com.google.android.flexbox.FlexItem.FLEX_SHRINK_NOT_SET;
 
 import static androidx.recyclerview.widget.RecyclerView.NO_POSITION;
 
+import android.graphics.drawable.Drawable;
 import android.util.SparseIntArray;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.CompoundButton;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,6 +38,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.view.MarginLayoutParamsCompat;
+import androidx.core.widget.CompoundButtonCompat;
 
 /**
  * Offers various calculations for Flexbox to use the common logic between the classes such as
@@ -317,7 +319,8 @@ class FlexboxHelper {
      */
     void calculateVerticalFlexLines(FlexLinesResult result, int widthMeasureSpec,
             int heightMeasureSpec, int needsCalcAmount, int fromIndex,
-            @Nullable List<FlexLine> existingLines) {
+            @Nullable List<FlexLine> existingLines)
+    {
         calculateFlexLines(result, heightMeasureSpec, widthMeasureSpec, needsCalcAmount,
                 fromIndex, NO_POSITION, existingLines);
     }
@@ -438,6 +441,8 @@ class FlexboxHelper {
                     addFlexLine(flexLines, flexLine, i, sumCrossSize);
                 }
                 continue;
+            } else if (child instanceof CompoundButton) {
+                evaluateMinimumSizeForCompoundButton((CompoundButton) child);
             }
 
             FlexItem flexItem = (FlexItem) child.getLayoutParams();
@@ -626,6 +631,28 @@ class FlexboxHelper {
         }
 
         result.mChildState = childState;
+    }
+
+    /**
+     * Compound buttons (ex. {{@link android.widget.CheckBox}}, {@link android.widget.ToggleButton})
+     * have a button drawable with minimum height and width specified for them.
+     * To align the behavior with CSS Flexbox we want to respect these minimum measurement to avoid
+     * these drawables from being cut off during calculation. When the compound button has a minimum
+     * width or height already specified we will not make any change since we assume those were
+     * voluntarily set by the user.
+     *
+     * @param compoundButton the compound button that need to be evaluated
+     */
+    private void evaluateMinimumSizeForCompoundButton(CompoundButton compoundButton) {
+        FlexItem flexItem = (FlexItem) compoundButton.getLayoutParams();
+        int minWidth = flexItem.getMinWidth();
+        int minHeight = flexItem.getMinHeight();
+
+        Drawable drawable = CompoundButtonCompat.getButtonDrawable(compoundButton);
+        int drawableMinWidth = drawable == null ? 0 : drawable.getMinimumWidth();
+        int drawableMinHeight = drawable == null ? 0 : drawable.getMinimumHeight();
+        flexItem.setMinWidth(minWidth == NOT_SET ? drawableMinWidth : minWidth);
+        flexItem.setMinHeight(minHeight == NOT_SET ? drawableMinHeight : minHeight);
     }
 
     /**

--- a/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
+++ b/flexbox/src/main/java/com/google/android/flexbox/FlexboxLayout.java
@@ -1598,12 +1598,12 @@ public class FlexboxLayout extends ViewGroup implements FlexContainer {
         /**
          * @see FlexItem#getMinWidth()
          */
-        private int mMinWidth;
+        private int mMinWidth = NOT_SET;
 
         /**
          * @see FlexItem#getMinHeight()
          */
-        private int mMinHeight;
+        private int mMinHeight = NOT_SET;
 
         /**
          * @see FlexItem#getMaxWidth()
@@ -1636,9 +1636,9 @@ public class FlexboxLayout extends ViewGroup implements FlexContainer {
                     .getFraction(R.styleable.FlexboxLayout_Layout_layout_flexBasisPercent, 1, 1,
                             FLEX_BASIS_PERCENT_DEFAULT);
             mMinWidth = a
-                    .getDimensionPixelSize(R.styleable.FlexboxLayout_Layout_layout_minWidth, 0);
+                    .getDimensionPixelSize(R.styleable.FlexboxLayout_Layout_layout_minWidth, NOT_SET);
             mMinHeight = a
-                    .getDimensionPixelSize(R.styleable.FlexboxLayout_Layout_layout_minHeight, 0);
+                    .getDimensionPixelSize(R.styleable.FlexboxLayout_Layout_layout_minHeight, NOT_SET);
             mMaxWidth = a.getDimensionPixelSize(R.styleable.FlexboxLayout_Layout_layout_maxWidth,
                     MAX_SIZE);
             mMaxHeight = a.getDimensionPixelSize(R.styleable.FlexboxLayout_Layout_layout_maxHeight,


### PR DESCRIPTION
CompoundButtons such as Checkboxes, when are allowed to shrink (flexShrink = 1f), during the recalculation can end up being shrunk more than what I would consider their "minimum size" since the negative space is calculated for all FlexItems in the shrinkFlexItems() method.

The image below shows the behavior explained above:

<img width="366" alt="70343552-e0be2300-1857-11ea-93a1-b72d4a5292dc" src="https://user-images.githubusercontent.com/5583539/71626926-f5d86880-2bef-11ea-8f74-52acd834063c.png">

In this PR I try to prevent these components to get completely shrunk by considering the minimum size of their button drawable. In this way, the drawable size will determine the minimum size of the widget unless a minWidth or minHeight are specified by the user. 

**Result:**

<img width="366" alt="70348737-9f337500-1863-11ea-92ae-1242306c788a" src="https://user-images.githubusercontent.com/5583539/71627132-240a7800-2bf1-11ea-962f-2dd1b7bc43ed.png">

The following approach also works when text is added to the Checkbox. In the image below it is possible to observe how the text of the checkbox is shrunk:

<img width="366" alt="Screenshot 2019-12-31 at 17 21 42" src="https://user-images.githubusercontent.com/5583539/71627385-6aaca200-2bf2-11ea-931f-3f2d9d5f0179.png">

This [Gist](https://gist.github.com/AlexBalo/38684b94a9919c0106483e35df304546) contains classes that can be used to test the scenario described above.